### PR TITLE
Add README.md and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,58 @@
+# CLAUDE.md
+
+Instructions for Claude Code working in this repository.
+
+## Repo structure
+
+The root directory contains the **generated site output** committed for GitHub Pages. Do not edit root-level files like `index.html`, `feed.xml`, `sitemap.xml`, or the category folders (`kotlin/`, `android/`, etc.) — they are overwritten on every CI build.
+
+All source work happens in `_jekyll/`:
+
+| Path | Purpose |
+|------|---------|
+| `_jekyll/_posts/` | Published blog posts |
+| `_jekyll/_drafts/` | Unpublished drafts |
+| `_jekyll/_config.yml` | Site configuration |
+| `_jekyll/_includes/` | Liquid template partials |
+| `_jekyll/_plugins/` | Custom Ruby plugins |
+| `_jekyll/assets/img/` | Images referenced by posts |
+| `.github/workflows/deploy.yaml` | CI/CD build and deploy workflow |
+
+## Adding a post
+
+Create `_jekyll/_posts/YYYY-MM-DD-slug.md` with this frontmatter:
+
+```yaml
+---
+layout: post
+title:  Post Title
+date:   YYYY-MM-DD HH:MM:SS +0700
+categories: kotlin android
+---
+```
+
+Existing categories: `kotlin`, `kotlin-library`, `android`, `data-class`
+
+## Deployment flow
+
+```
+push to master (changes in _jekyll/**)
+  → GitHub Actions: bundle exec jekyll build
+  → copies _jekyll/_site/* to repo root
+  → opens PR with auto-deploy label
+  → merge PR to publish
+```
+
+Never commit generated output (root HTML/XML/assets) manually — CI owns those files.
+
+## Ruby version
+
+3.4.2 — set in `.github/workflows/deploy.yaml` and used by Bundler.
+
+## Site config
+
+- **URL**: https://afanasev.net
+- **Theme**: minima 2.5
+- **Plugins**: jekyll-feed, jekyll-tidy, jekyll-sitemap
+- **Comments**: Disqus (`afanasev-net`)
+- **Analytics**: Google Analytics UA-60387111-7

--- a/README.md
+++ b/README.md
@@ -1,0 +1,60 @@
+# afanasev.net
+
+Personal tech blog at [afanasev.net](https://afanasev.net), built with [Jekyll](https://jekyllrb.com) and hosted on GitHub Pages.
+
+## Repo layout
+
+This repo has an unconventional structure required by GitHub Pages:
+
+```
+/                   ← generated site output (do not edit directly)
+├── _jekyll/        ← all source files live here
+│   ├── _posts/     ← blog posts
+│   ├── _drafts/    ← unpublished drafts
+│   ├── _config.yml ← site configuration
+│   └── ...
+└── .github/
+    └── workflows/
+        └── deploy.yaml
+```
+
+The root-level HTML, XML, and asset files are the compiled output of the Jekyll build — managed automatically by CI. **All content and configuration changes go in `_jekyll/`.**
+
+## Local development
+
+```bash
+cd _jekyll
+bundle install
+bundle exec jekyll serve
+```
+
+The site will be available at `http://localhost:4000`.
+
+## Writing a post
+
+Create a new file in `_jekyll/_posts/` following the naming convention `YYYY-MM-DD-slug.md`:
+
+```markdown
+---
+layout: post
+title:  Your Post Title
+date:   2025-01-01 12:00:00 +0700
+categories: kotlin android
+---
+
+Post content here.
+```
+
+**Existing categories:** `kotlin`, `kotlin-library`, `android`, `data-class`
+
+Drafts go in `_jekyll/_drafts/` and are excluded from the build until moved to `_posts/`.
+
+## Deployment
+
+Pushing to `master` with any changes under `_jekyll/` triggers the GitHub Actions workflow:
+
+1. Builds the site with `bundle exec jekyll build`
+2. Copies the output from `_jekyll/_site/` to the repo root
+3. Opens a pull request with the generated changes
+
+Merge the PR to publish.


### PR DESCRIPTION
## Summary

- **README.md** — documents the non-obvious repo layout (root = generated output, `_jekyll/` = source), local dev setup, post frontmatter format, and the CI deployment flow
- **CLAUDE.md** — project instructions for Claude Code: what not to edit, how to add posts, key paths, deployment flow, Ruby version, and site config summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)